### PR TITLE
Fix Tailwind plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@radix-ui/react-dialog": "^1.1.13",
     "@radix-ui/react-select": "^2.2.4",
     "@radix-ui/react-tooltip": "^1.2.6",
-    "@tailwindcss/postcss": "^4.1.8",
     "aws-amplify": "^6.14.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,6 @@
 export default {
   plugins: {
-    "@tailwindcss/postcss": {}
-  }
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,10 @@
+export default {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: [],
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2385,16 +2385,6 @@
     "@tailwindcss/oxide-win32-arm64-msvc" "4.1.8"
     "@tailwindcss/oxide-win32-x64-msvc" "4.1.8"
 
-"@tailwindcss/postcss@^4.1.8":
-  version "4.1.8"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/postcss/-/postcss-4.1.8.tgz#b12374b49f3accd9bd902a4324d124e67803350f"
-  integrity sha512-vB/vlf7rIky+w94aWMw34bWW1ka6g6C3xIOdICKX2GC0VcLtL6fhlLiafF0DVIwa9V6EHz8kbWMkS2s2QvvNlw==
-  dependencies:
-    "@alloc/quick-lru" "^5.2.0"
-    "@tailwindcss/node" "4.1.8"
-    "@tailwindcss/oxide" "4.1.8"
-    postcss "^8.4.41"
-    tailwindcss "4.1.8"
 
 "@ts-morph/common@~0.19.0":
   version "0.19.0"


### PR DESCRIPTION
## Summary
- restore standard PostCSS plugin names
- drop unused `@tailwindcss/postcss` dependency

## Testing
- `yarn install` *(fails: tunneling socket could not be established)*
- `yarn build` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684970faf1448325a3b96fd7448630f2